### PR TITLE
Add proof-of-concept wrapper

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -2,3 +2,5 @@
 
 README.md
 static
+src/wrapper
+src/index.ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * as DevRev from "./api";
-export { DevRevClient } from "./Client";
+export { DevRevClient } from "./wrapper/DevRevClient";
 export { DevRevEnvironment } from "./environments";
 export { DevRevError, DevRevTimeoutError } from "./errors";

--- a/src/wrapper/DevRevClient.ts
+++ b/src/wrapper/DevRevClient.ts
@@ -1,0 +1,20 @@
+import { DevRevClient as FernClient } from "../Client";
+import { DevRev } from "@fern-api/devrev";
+
+export class DevRevClient extends FernClient {
+    public async createWorkAndTags(request: DevRev.WorksCreateRequest): Promise<DevRev.WorksCreateResponse> {
+        // first, create all the tags
+        if (request.tags != null) {
+            for (const tag of request.tags) {
+                await this.tags.create({
+                    name: tag.id,
+                });
+            }
+        }
+
+        // then, create the work
+        const createWorkResponse = await this.works.create(request);
+
+        return createWorkResponse;
+    }
+}


### PR DESCRIPTION
This PR demonstrates a proof of concept for adding a custom method to the `DevRevClient`.

In this PR, I've added the method `createWorkAndTags` which creates a work and its tags. I know this doesn't really make sense, but just a proof of concept :)

```ts
import { DevRevClient } from "@fern-api/devrev";

const client = new DevRevClient({
  apiKey: "YOUR_API_KEY",
});

const { work } = await client.createWorkAndTags({ ... });
```